### PR TITLE
Parsing pour la visibilité des classes

### DIFF
--- a/Main/Compile.ml
+++ b/Main/Compile.ml
@@ -9,7 +9,7 @@ let execute lexbuf verbose =
     try
         let result = Parsexpr.expressionList Lexexpr.readtoken lexbuf in
         (* To parse classes *)
-        (* let result = Parseclass.classdeclaration Lexclass.readtoken lexbuf in *)
+        (* let result = Parseclass.classdeclarationlist Lexclass.readtoken lexbuf in *)
         print_string "\n --- Result --- \n";
         print_string result;
         print_string "\n";

--- a/Parsing/lexclass.mll
+++ b/Parsing/lexclass.mll
@@ -16,10 +16,18 @@ let class_keyword = "class"
 rule nexttoken = parse 
     | blank+ { nexttoken lexbuf }
     | newline { Lexing.new_line lexbuf; nexttoken lexbuf }
+    | eof { EOF } 
     | class_keyword { CLASS } 
-    | ident as i { IDENT i }
     | lbrace { LBRACE }
     | rbrace { RBRACE }
+    | "public" { PUBLIC }
+    | "protected" { PROTECTED } 
+    | "private" { PRIVATE }
+    | "abstract" { ABSTRACT }
+    | "static" { STATIC }
+    | "final" { FINAL }
+    | "strictfp" { STRICTFP } 
+    | ident as i { IDENT i }
 
 {
 
@@ -30,6 +38,13 @@ let printtoken = function
     | IDENT i -> print_string "IDENT("; print_string i; print_string ")"
     | LBRACE -> print_string "{"
     | RBRACE -> print_string "}"
+    | PUBLIC -> print_string "public"
+    | PROTECTED -> print_string "protected"
+    | PRIVATE -> print_string "private"
+    | ABSTRACT -> print_string "abstract"
+    | STATIC -> print_string "static"
+    | FINAL -> print_string "final"
+    | STRICTFP -> print_string "strictfp" 
 
 let rec readtoken buffer = 
     let res = nexttoken buffer in

--- a/Parsing/lexclass.mll
+++ b/Parsing/lexclass.mll
@@ -8,18 +8,15 @@ let real = digit* ('.' digit*)?
 let ident = letter (letter | digit | '_')*
 let newline = ('\010' | '\013' | "\013\010")
 let blank = [' ' '\009']
-let semicolon = ';'
-let lbrace = "{"
-let rbrace = "}"
-let class_keyword = "class"
 
 rule nexttoken = parse 
     | blank+ { nexttoken lexbuf }
     | newline { Lexing.new_line lexbuf; nexttoken lexbuf }
     | eof { EOF } 
-    | class_keyword { CLASS } 
-    | lbrace { LBRACE }
-    | rbrace { RBRACE }
+    | ";" { SEMICOLON } 
+    | "{" { LBRACE }
+    | "}" { RBRACE }
+    | "class" { CLASS } 
     | "public" { PUBLIC }
     | "protected" { PROTECTED } 
     | "private" { PRIVATE }

--- a/Parsing/parseclass.mly
+++ b/Parsing/parseclass.mly
@@ -4,16 +4,15 @@
 %token <string> TYPE IDENT
 %token <float> NUMBER
 
-%start <string> classDeclarationList
+%start <string> compilationUnitList
 
 %%
 
 classBody:
     LBRACE RBRACE { " { ... }" }
 
-classDeclarationList:
-      ncd=normalClassDeclaration EOF { ncd }
-    | ncd=normalClassDeclaration cdl=classDeclarationList EOF { ncd^"\n"^cdl }  
+classDeclaration:
+    ncd=normalClassDeclaration { ncd }
 
 classModifier:
       PUBLIC { "public" }
@@ -24,11 +23,18 @@ classModifier:
     | FINAL { "final" }
     | STRICTFP { "strictfp" }
 
+compilationUnitList: 
+      tp=typeDeclaration EOF { tp } 
+    | tp=typeDeclaration cul=compilationUnitList EOF { tp^"\n"^cul }  
+
 identifier:
     id=IDENT { id }
 
 normalClassDeclaration:
       CLASS id=identifier cb=classBody { "class "^id^cb } 
     | cm=classModifier CLASS id=identifier cb=classBody { cm^" class "^id^cb}
+
+typeDeclaration:
+    cd=classDeclaration { cd } 
 
 %%

--- a/Parsing/parseclass.mly
+++ b/Parsing/parseclass.mly
@@ -1,23 +1,21 @@
-%token SEMICOLON EOF 
-%token CLASS
-%token PUBLIC PROTECTED PRIVATE ABSTRACT STATIC FINAL STRICTFP
-%token LBRACE RBRACE
+%token EOF 
+%token SEMICOLON LBRACE RBRACE
+%token CLASS PUBLIC PROTECTED PRIVATE ABSTRACT STATIC FINAL STRICTFP
 %token <string> TYPE IDENT
 %token <float> NUMBER
 
-%start <string> classdeclarationlist
+%start <string> classDeclarationList
 
 %%
 
-classdeclarationlist:
-      ncd=normalclassdeclaration EOF { ncd }
-    | ncd=normalclassdeclaration cdl=classdeclarationlist EOF { ncd^"\n"^cdl }  
+classBody:
+    LBRACE RBRACE { " { ... }" }
 
-normalclassdeclaration:
-      CLASS id=identifier cb=classbody { "class "^id^cb } 
-    | cm=classmodifier CLASS id=identifier cb=classbody { cm^" class "^id^cb}
+classDeclarationList:
+      ncd=normalClassDeclaration EOF { ncd }
+    | ncd=normalClassDeclaration cdl=classDeclarationList EOF { ncd^"\n"^cdl }  
 
-classmodifier:
+classModifier:
       PUBLIC { "public" }
     | PROTECTED { "protected" }
     | PRIVATE { "private" }
@@ -26,10 +24,11 @@ classmodifier:
     | FINAL { "final" }
     | STRICTFP { "strictfp" }
 
-classbody:
-    LBRACE RBRACE { " { ... }" }
-
 identifier:
     id=IDENT { id }
+
+normalClassDeclaration:
+      CLASS id=identifier cb=classBody { "class "^id^cb } 
+    | cm=classModifier CLASS id=identifier cb=classBody { cm^" class "^id^cb}
 
 %%

--- a/Parsing/parseclass.mly
+++ b/Parsing/parseclass.mly
@@ -1,23 +1,35 @@
 %token SEMICOLON EOF 
 %token CLASS
+%token PUBLIC PROTECTED PRIVATE ABSTRACT STATIC FINAL STRICTFP
 %token LBRACE RBRACE
 %token <string> TYPE IDENT
 %token <float> NUMBER
 
-%start <string> classdeclaration
+%start <string> classdeclarationlist
 
 %%
 
-classdeclaration:
-    ncd=normalclassdeclaration { ncd }
+classdeclarationlist:
+      ncd=normalclassdeclaration EOF { ncd }
+    | ncd=normalclassdeclaration cdl=classdeclarationlist EOF { ncd^"\n"^cdl }  
 
 normalclassdeclaration:
-    CLASS id=identifier classbody { "class("^id^")" } 
+      CLASS id=identifier cb=classbody { "class "^id^cb } 
+    | cm=classmodifier CLASS id=identifier cb=classbody { cm^" class "^id^cb}
+
+classmodifier:
+      PUBLIC { "public" }
+    | PROTECTED { "protected" }
+    | PRIVATE { "private" }
+    | ABSTRACT { "abstract" }
+    | STATIC { "static" }
+    | FINAL { "final" }
+    | STRICTFP { "strictfp" }
 
 classbody:
-    LBRACE RBRACE { "{ classbody }" }
+    LBRACE RBRACE { " { ... }" }
 
 identifier:
-    id=IDENT { "ident("^id^")" }
+    id=IDENT { id }
 
 %%

--- a/Tests/testclass.java
+++ b/Tests/testclass.java
@@ -1,2 +1,8 @@
 class classA { } 
 
+public class public_class { }
+
+protected class protected_class { } 
+
+private class private_class { } 
+


### PR DESCRIPTION
Quelques ajouts sur le parsing côté classe.
Ne pas oublier de commenter la ligne 10 de Compile.ml et de décommenter la ligne 12 du même fichier pour faire compiler la branche. J'ai utilisé ceci pour ne pas avoir à gérer tout le temps des conflits avec la version sur develop. 
Il faudra sans doute à terme, travailler sur le même fichier .mll et .mly
