### PR TITLE
Parsing: Remove modifiers keyword not present in miniJava language

### DIFF
--- a/Parsing/lexer.mll
+++ b/Parsing/lexer.mll
@@ -20,13 +20,7 @@ rule nexttoken = parse
     | "{" { LBRACE }
     | "}" { RBRACE }
     | "class" { CLASS } 
-    | "public" { PUBLIC }
-    | "protected" { PROTECTED } 
-    | "private" { PRIVATE }
-    | "abstract" { ABSTRACT }
     | "static" { STATIC }
-    | "final" { FINAL }
-    | "strictfp" { STRICTFP }
     | "int" { INT }
     | "float" { FLOAT }
     | real as n { NUMBER (float_of_string n) }
@@ -44,13 +38,7 @@ let printtoken = function
     | CLASS -> print_string "class" 
     | LBRACE -> print_string "{"
     | RBRACE -> print_string "}"
-    | PUBLIC -> print_string "public"
-    | PROTECTED -> print_string "protected"
-    | PRIVATE -> print_string "private"
-    | ABSTRACT -> print_string "abstract"
     | STATIC -> print_string "static"
-    | FINAL -> print_string "final"
-    | STRICTFP -> print_string "strictfp" 
     | INT -> print_string "int"
     | FLOAT -> print_string "float"
 

--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -1,6 +1,6 @@
 %token EOF 
 %token COMMA SEMICOLON LBRACE RBRACE
-%token CLASS PUBLIC PROTECTED PRIVATE ABSTRACT STATIC FINAL STRICTFP
+%token CLASS STATIC 
 %token INT FLOAT
 %token <string> IDENT
 %token <float> NUMBER
@@ -72,12 +72,6 @@ floatingPointType:
     FLOAT { "float" } 
 
 classModifier:
-      PUBLIC { "public" }
-    | PROTECTED { "protected" }
-    | PRIVATE { "private" }
-    | ABSTRACT { "abstract" }
-    | STATIC { "static" }
-    | FINAL { "final" }
-    | STRICTFP { "strictfp" }
+    STATIC { "static" }
 
 %%

--- a/Tests/testclass.java
+++ b/Tests/testclass.java
@@ -1,1 +1,1 @@
-public class classA { int a; } 
+static class classA { int a; } 


### PR DESCRIPTION
Pour s'adapter aux spécifications du langage [miniJava](https://files.slack.com/files-pri/T0E0NQN74-F0HDZBV3K/minijava.pdf), j'ai supprimé quelques `modifiers` de classe qui n'étaient pas demandés pour miniJava. 

Est-ce qu'il faut suivre le diagramme EBNF fourni dans ce pdf ? Dans ce cas-là, le projet est bientôt terminé, car ce diagramme EBNF est facile à implémenter, j'ai l'impression. 
