### PR TITLE
Add grammar rules which follow miniJava specification

### DIFF
--- a/Main/Compile.ml
+++ b/Main/Compile.ml
@@ -7,7 +7,7 @@ open Lexing
 (* verbose is a boolean that you can use to switch to a verbose output (for example, to dump all the ast) *)
 let execute lexbuf verbose = 
     try
-        let result = Parser.compilationUnitList Lexer.readtoken lexbuf in
+        let result = Parser.start Lexer.readtoken lexbuf in
         print_string "\n --- Result --- \n";
         print_string result;
         print_string "\n";

--- a/Parsing/lexer.mll
+++ b/Parsing/lexer.mll
@@ -5,9 +5,12 @@
 }
 
 let letter = ['a'-'z' 'A'-'Z']
+let capital = ['A'-'Z']
+let lowercase = ['a'-'z']
 let digit = ['0'-'9']
 let real = digit* ('.' digit*)?
-let ident = letter (letter | digit | '_')*
+let uident = capital ( letter | digit | '_')*
+let lident = lowercase ( letter | digit | '_')*
 let newline = ('\010' | '\013' | "\013\010")
 let blank = [' ' '\009']
 
@@ -24,7 +27,8 @@ rule nexttoken = parse
     | "int" { INT }
     | "float" { FLOAT }
     | real as n { NUMBER (float_of_string n) }
-    | ident as i { IDENT i }
+    | uident as u { UIDENT u }
+    | lident as l { LIDENT l }
     | _ { raise_error LexingError lexbuf }
 
 {
@@ -34,7 +38,8 @@ let printtoken = function
     | COMMA -> print_string ","
     | SEMICOLON -> print_string ";"
     | NUMBER n -> print_string "NUMBER("; print_float n; print_string ")" 
-    | IDENT i -> print_string "IDENT("; print_string i; print_string ")"
+    | UIDENT u -> print_string "UIDENT("; print_string u; print_string ")"
+    | LIDENT l -> print_string "LIDENT("; print_string l; print_string ")"
     | CLASS -> print_string "class" 
     | LBRACE -> print_string "{"
     | RBRACE -> print_string "}"

--- a/Parsing/lexer.mll
+++ b/Parsing/lexer.mll
@@ -20,13 +20,7 @@ rule nexttoken = parse
     | "{" { LBRACE }
     | "}" { RBRACE }
     | "class" { CLASS } 
-    | "public" { PUBLIC }
-    | "protected" { PROTECTED } 
-    | "private" { PRIVATE }
-    | "abstract" { ABSTRACT }
     | "static" { STATIC }
-    | "final" { FINAL }
-    | "strictfp" { STRICTFP }
     | "int" { INT }
     | "float" { FLOAT }
     | real as n { NUMBER (float_of_string n) }
@@ -44,13 +38,7 @@ let printtoken = function
     | CLASS -> print_string "class" 
     | LBRACE -> print_string "{"
     | RBRACE -> print_string "}"
-    | PUBLIC -> print_string "public"
-    | PROTECTED -> print_string "protected"
-    | PRIVATE -> print_string "private"
-    | ABSTRACT -> print_string "abstract"
     | STATIC -> print_string "static"
-    | FINAL -> print_string "final"
-    | STRICTFP -> print_string "strictfp" 
     | INT -> print_string "int"
     | FLOAT -> print_string "float"
 

--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -1,6 +1,6 @@
 %token EOF 
 %token COMMA SEMICOLON LBRACE RBRACE
-%token CLASS PUBLIC PROTECTED PRIVATE ABSTRACT STATIC FINAL STRICTFP
+%token CLASS STATIC 
 %token INT FLOAT
 %token <string> IDENT
 %token <float> NUMBER
@@ -72,12 +72,6 @@ floatingPointType:
     FLOAT { "float" } 
 
 classModifier:
-      PUBLIC { "public" }
-    | PROTECTED { "protected" }
-    | PRIVATE { "private" }
-    | ABSTRACT { "abstract" }
-    | STATIC { "static" }
-    | FINAL { "final" }
-    | STRICTFP { "strictfp" }
+    STATIC { "static" }
 
 %%

--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -5,73 +5,38 @@
 %token <string> UIDENT LIDENT
 %token <float> NUMBER
 
-%start <string> compilationUnitList
+%start <string> start
 
 %%
 
-(* expressionList:
-    e=expression EOF { e }
-    |  e=expression el=expressionList EOF { e^"\n"^el } 
-*)
+start:
+      EOF { "eof" }
+    | joel=jclass_or_expr_list EOF { joel }
 
+jclass_or_expr_list:
+      joe=jclass_or_expr { joe }
+    | joe=jclass_or_expr joel=jclass_or_expr_list { joe^"\n"^joel }
+
+jclass_or_expr:
+      jc=jclass { jc }
+
+jclass:
+    CLASS ui=UIDENT LBRACE ajl=attribute_or_jmethod_list RBRACE 
+        { "class "^ui^" { "^ajl^" } " }
+        
+attribute_or_jmethod_list:
+      aoj=attribute_or_jmethod { aoj } 
+    | aoj=attribute_or_jmethod ajl=attribute_or_jmethod_list { aoj^"\n"^ajl } 
+
+attribute_or_jmethod:
+    a=attribute { a } 
    
-compilationUnitList: 
-      tp=typeDeclaration EOF { tp } 
-    | tp=typeDeclaration cul=compilationUnitList EOF { tp^"\n"^cul }  
+attribute:
+    jt=jtype li=LIDENT SEMICOLON { jt^" "^li^";" } 
 
-typeDeclaration:
-    cd=classDeclaration { cd } 
-
-classDeclaration:
-    ncd=normalClassDeclaration { ncd }
-
-normalClassDeclaration:
-      CLASS id=identifier cb=classBody { "class "^id^cb } 
-    | cm=classModifier CLASS id=identifier cb=classBody { cm^" class "^id^cb}
-
-classBody:
-    LBRACE cbd=classBodyDeclaration RBRACE { " {"^cbd^" }" }
-
-classBodyDeclaration:
-    cmd=classMemberDeclaration { cmd }
-
-classMemberDeclaration:
-      fd=fieldDeclaration { fd } 
-    | SEMICOLON { ";" } 
- 
-fieldDeclaration:
-    ut=unannType vdl=variableDeclaratorList SEMICOLON { ut^" "^vdl^";"}
-
-variableDeclaratorList:
-    vd=variableDeclarator { vd }
-    | vd=variableDeclarator COMMA vdl=variableDeclaratorList { vd^", "^vdl }
-
-variableDeclarator:
-    vdi=variableDeclaratorId { vdi }
-
-variableDeclaratorId:
-    id=identifier { id } 
-
-identifier:
-    id=UIDENT { id }
-
-unannType:
-    upt=unannPrimitiveType { upt }
-
-unannPrimitiveType:
-    nt=numericType { nt } 
-
-numericType:
-      it=integralType { it } 
-    | fpt=floatingPointType { fpt } 
-
-integralType:
-    INT { "int" } 
-
-floatingPointType:
-    FLOAT { "float" } 
-
-classModifier:
-    STATIC { "static" }
+jtype:
+      INT { "int" }
+    | FLOAT { "float" }
+    | ui=UIDENT { ui } 
 
 %%

--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -2,7 +2,7 @@
 %token COMMA SEMICOLON LBRACE RBRACE
 %token CLASS STATIC 
 %token INT FLOAT
-%token <string> IDENT
+%token <string> UIDENT LIDENT
 %token <float> NUMBER
 
 %start <string> compilationUnitList
@@ -53,7 +53,7 @@ variableDeclaratorId:
     id=identifier { id } 
 
 identifier:
-    id=IDENT { id }
+    id=UIDENT { id }
 
 unannType:
     upt=unannPrimitiveType { upt }

--- a/Tests/testclass.java
+++ b/Tests/testclass.java
@@ -1,1 +1,1 @@
-static class classA { int a; } 
+class ClassA { int a; } 

--- a/Tests/testclass.java
+++ b/Tests/testclass.java
@@ -1,1 +1,1 @@
-public class classA { int a; } 
+static class classA { int a; } 


### PR DESCRIPTION
J'étais initialement parti pour suivre la spec de Java 8. Selon la spec du miniJava, j'ai fait plusieurs modifs : 
- Suppression des modifiers de class (public, private, etc)
- Distinction des identifiants de class/types avec une lettre majuscule, et identifiants de variable avec une lettre minuscule. 
- Début de construction de la grammaire du miniJava. 
- Modification du code Java de test pour être conforme avec miniJava. Le fichier testclass.java est correctement parsé. 
