### PR TITLE
Déclaration des classes + méthodes

### DIFF
--- a/Main/Compile.ml
+++ b/Main/Compile.ml
@@ -7,7 +7,7 @@ open Lexing
 (* verbose is a boolean that you can use to switch to a verbose output (for example, to dump all the ast) *)
 let execute lexbuf verbose = 
     try
-        let result = Parser.compilationUnitList Lexer.readtoken lexbuf in
+        let result = Parser.compilationUnit Lexer.readtoken lexbuf in
         print_string "\n --- Result --- \n";
         print_string result;
         print_string "\n";

--- a/Main/Compile.ml
+++ b/Main/Compile.ml
@@ -7,7 +7,7 @@ open Lexing
 (* verbose is a boolean that you can use to switch to a verbose output (for example, to dump all the ast) *)
 let execute lexbuf verbose = 
     try
-        let result = Parser.start Lexer.readtoken lexbuf in
+        let result = Parser.compilationUnitList Lexer.readtoken lexbuf in
         print_string "\n --- Result --- \n";
         print_string result;
         print_string "\n";

--- a/Parsing/lexer.mll
+++ b/Parsing/lexer.mll
@@ -5,12 +5,10 @@
 }
 
 let letter = ['a'-'z' 'A'-'Z']
-let capital = ['A'-'Z']
 let lowercase = ['a'-'z']
 let digit = ['0'-'9']
 let real = digit* ('.' digit*)?
-let uident = capital ( letter | digit | '_')*
-let lident = lowercase ( letter | digit | '_')*
+let ident = letter ( letter | digit | '_')*
 let newline = ('\010' | '\013' | "\013\010")
 let blank = [' ' '\009']
 
@@ -19,16 +17,24 @@ rule nexttoken = parse
     | newline { Lexing.new_line lexbuf; nexttoken lexbuf }
     | eof { EOF }
     | "," { COMMA }
-    | ";" { SEMICOLON } 
+    | ";" { SEMICOLON }
+    | "(" { LPAREN }
+    | ")" { RPAREN }
     | "{" { LBRACE }
     | "}" { RBRACE }
-    | "class" { CLASS } 
-    | "static" { STATIC }
     | "int" { INT }
     | "float" { FLOAT }
+    | "class" { CLASS }
+    | "abstract" { ABSTRACT }
+    | "final" { FINAL }
+    | "native" { NATIVE } 
+    | "private" { PRIVATE } 
+    | "protected" { PROTECTED } 
+    | "public" { PUBLIC } 
+    | "static" { STATIC } 
+    | "strictfp" { STRICTFP } 
     | real as n { NUMBER (float_of_string n) }
-    | uident as u { UIDENT u }
-    | lident as l { LIDENT l }
+    | ident as i { IDENT i }
     | _ { raise_error LexingError lexbuf }
 
 {
@@ -37,16 +43,23 @@ let printtoken = function
     | EOF -> print_string "EOF"
     | COMMA -> print_string ","
     | SEMICOLON -> print_string ";"
-    | NUMBER n -> print_string "NUMBER("; print_float n; print_string ")" 
-    | UIDENT u -> print_string "UIDENT("; print_string u; print_string ")"
-    | LIDENT l -> print_string "LIDENT("; print_string l; print_string ")"
-    | CLASS -> print_string "class" 
+    | LPAREN -> print_string "("
+    | RPAREN -> print_string ")"
     | LBRACE -> print_string "{"
     | RBRACE -> print_string "}"
-    | STATIC -> print_string "static"
     | INT -> print_string "int"
     | FLOAT -> print_string "float"
-
+    | CLASS -> print_string "class" 
+    | ABSTRACT -> print_string "abstract"
+    | FINAL -> print_string "final"
+    | NATIVE -> print_string "native"
+    | PRIVATE -> print_string "private"
+    | PROTECTED -> print_string "protected"
+    | PUBLIC -> print_string "public"
+    | STATIC -> print_string "static"
+    | STRICTFP -> print_string "strictfp" 
+    | NUMBER n -> print_string "NUMBER("; print_float n; print_string ")" 
+    | IDENT i -> print_string "IDENT("; print_string i; print_string ")"
 
 let rec readtoken buffer = 
     let res = nexttoken buffer in

--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -1,42 +1,111 @@
+(* operators *)
+
+(* delimitors *)
+%token COMMA SEMICOLON LPAREN RPAREN LBRACE RBRACE
+
+(* keyword *)
+%token ABSTRACT CLASS INT FINAL FLOAT NATIVE PRIVATE PROTECTED PUBLIC STATIC STRICTFP 
+SYNCHRONIZED
+
+(* special *)
 %token EOF 
-%token COMMA SEMICOLON LBRACE RBRACE
-%token CLASS STATIC 
-%token INT FLOAT
-%token <string> UIDENT LIDENT
+%token <string> IDENT
 %token <float> NUMBER
 
-%start <string> start
+%start <string> compilationUnitList
 
 %%
 
-start:
-      EOF { "eof" }
-    | joel=jclass_or_expr_list EOF { joel }
+classBody:
+    LBRACE cbd=classBodyDeclaration RBRACE { " {"^cbd^" }" }
 
-jclass_or_expr_list:
-      joe=jclass_or_expr { joe }
-    | joe=jclass_or_expr joel=jclass_or_expr_list { joe^"\n"^joel }
+classBodyDeclaration:
+    cmd=classMemberDeclaration { cmd }
 
-jclass_or_expr:
-      jc=jclass { jc }
+classDeclaration:
+    ncd=normalClassDeclaration { ncd }
 
-jclass:
-    CLASS ui=UIDENT LBRACE ajl=attribute_or_jmethod_list RBRACE 
-        { "class "^ui^" { "^ajl^" } " }
-        
-attribute_or_jmethod_list:
-      aoj=attribute_or_jmethod { aoj } 
-    | aoj=attribute_or_jmethod ajl=attribute_or_jmethod_list { aoj^"\n"^ajl } 
+classMemberDeclaration:
+      (*fd=fieldDeclaration { fd } *)
+    | md=methodDeclaration { md }
+    | SEMICOLON { ";" } 
+    
+classModifier:
+      PUBLIC { "public" }
+    | PROTECTED { "protected" }
+    | PRIVATE { "private" }
+    | ABSTRACT { "abstract" }
+    | STATIC { "static" }
+    | FINAL { "final" }
+    | STRICTFP { "strictfp" }
 
-attribute_or_jmethod:
-    a=attribute { a } 
-   
-attribute:
-    jt=jtype li=LIDENT SEMICOLON { jt^" "^li^";" } 
+compilationUnitList: 
+      tp=typeDeclaration EOF { tp } 
+    | tp=typeDeclaration cul=compilationUnitList EOF { tp^"\n"^cul }
 
-jtype:
-      INT { "int" }
-    | FLOAT { "float" }
-    | ui=UIDENT { ui } 
+fieldDeclaration:
+    ut=unannType vdl=variableDeclaratorList SEMICOLON { ut^" "^vdl^";"}
 
+floatingPointType:
+    FLOAT { "float" } 
+
+identifier:
+    id=IDENT { id }
+
+integralType:
+    INT { "int" } 
+    
+methodBody:
+    SEMICOLON { ";" }
+
+methodDeclaration:
+      mh=methodHeader mb=methodBody { mh^" "^mb }
+    | mm=methodModifier mh=methodHeader mb=methodBody { mm^" "^mh^" "^mb }
+
+methodDeclarator:
+    id=identifier LPAREN RPAREN { id^" ( )" } 
+
+methodHeader:
+    r=result md=methodDeclarator { r^" "^md } 
+
+methodModifier:
+      PUBLIC { "public" }
+    | PROTECTED { "protected" }
+    | PRIVATE { "private" }
+    | ABSTRACT { "abstract" }
+    | STATIC { "static" }
+    | FINAL { "final" }
+    | SYNCHRONIZED { "synchronized" } 
+    | NATIVE { "native" } 
+    | STRICTFP { "strictfp" }
+
+normalClassDeclaration:
+      CLASS id=identifier cb=classBody { "class "^id^cb } 
+    | cm=classModifier CLASS id=identifier cb=classBody { cm^" class "^id^cb}
+
+numericType:
+      it=integralType { it } 
+    | fpt=floatingPointType { fpt } 
+
+result:
+    ut=unannType { ut }
+
+typeDeclaration:
+    cd=classDeclaration { cd }
+
+unannPrimitiveType:
+    nt=numericType { nt }
+
+unannType:
+    upt=unannPrimitiveType { upt }
+
+variableDeclarator:
+    vdi=variableDeclaratorId { vdi }
+
+variableDeclaratorId:
+    id=identifier { id }
+
+variableDeclaratorList:
+    vd=variableDeclarator { vd }
+    | vd=variableDeclarator COMMA vdl=variableDeclaratorList { vd^", "^vdl }
 %%

--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -12,24 +12,35 @@ SYNCHRONIZED
 %token <string> IDENT
 %token <float> NUMBER
 
-%start <string> compilationUnitList
+%start <string> compilationUnit
 
 %%
 
-classBody:
-    LBRACE cbd=classBodyDeclaration RBRACE { " {"^cbd^" }" }
+(* 7.3 Compilation Units *)
+compilationUnit: 
+      tps=typeDeclarations EOF { tps } 
 
-classBodyDeclaration:
-    cmd=classMemberDeclaration { cmd }
+typeDeclarations:
+      tp=typeDeclaration { tp }
+    | tps=typeDeclarations tp=typeDeclaration { tps^"\n"^tp }
 
+(* 7.6 Top Level Type Declarations *)
+typeDeclaration:
+      cd=classDeclaration { cd }
+    | SEMICOLON { ";" } 
+
+(* 8.1 Class Declaration *)
 classDeclaration:
     ncd=normalClassDeclaration { ncd }
 
-classMemberDeclaration:
-      (*fd=fieldDeclaration { fd } *)
-    | md=methodDeclaration { md }
-    | SEMICOLON { ";" } 
-    
+normalClassDeclaration:
+      CLASS id=identifier cb=classBody { "class "^id^" "^cb } 
+    | cms=classModifiers CLASS id=identifier cb=classBody { cms^" class "^id^" "^cb }
+
+classModifiers:
+      cm=classModifier { cm }
+    | cms=classModifiers cm=classModifier { cms^" "^cm }
+
 classModifier:
       PUBLIC { "public" }
     | PROTECTED { "protected" }
@@ -39,34 +50,39 @@ classModifier:
     | FINAL { "final" }
     | STRICTFP { "strictfp" }
 
-compilationUnitList: 
-      tp=typeDeclaration EOF { tp } 
-    | tp=typeDeclaration cul=compilationUnitList EOF { tp^"\n"^cul }
+classBody:
+      LBRACE cbds=classBodyDeclarations RBRACE { " {"^cbds^" }" }
+    | LBRACE RBRACE { " {} "}
 
+classBodyDeclarations:
+      cbd=classBodyDeclaration { cbd }
+    | cbds=classBodyDeclarations cbd=classBodyDeclaration { cbds^"\n"^cbd }
+
+classBodyDeclaration:
+      cmd=classMemberDeclaration { cmd }
+
+classMemberDeclaration:
+      (*fd=fieldDeclaration { fd } *)
+    | md=methodDeclaration { md }
+    | SEMICOLON { ";" } 
+    
+(* 8.3 Field Declarations *)
 fieldDeclaration:
     ut=unannType vdl=variableDeclaratorList SEMICOLON { ut^" "^vdl^";"}
 
-floatingPointType:
-    FLOAT { "float" } 
-
-identifier:
-    id=IDENT { id }
-
-integralType:
-    INT { "int" } 
-    
-methodBody:
-    SEMICOLON { ";" }
-
+(* 8.4 Method Declarations *)
 methodDeclaration:
       mh=methodHeader mb=methodBody { mh^" "^mb }
-    | mm=methodModifier mh=methodHeader mb=methodBody { mm^" "^mh^" "^mb }
+
+methodHeader:
+    r=result md=methodDeclarator { r^" "^md } 
 
 methodDeclarator:
     id=identifier LPAREN RPAREN { id^" ( )" } 
 
-methodHeader:
-    r=result md=methodDeclarator { r^" "^md } 
+methodModifiers:
+      mm=methodModifier { mm }
+    | mms=methodModifiers mm=methodModifier { mms^" "^mm }
 
 methodModifier:
       PUBLIC { "public" }
@@ -79,9 +95,18 @@ methodModifier:
     | NATIVE { "native" } 
     | STRICTFP { "strictfp" }
 
-normalClassDeclaration:
-      CLASS id=identifier cb=classBody { "class "^id^cb } 
-    | cm=classModifier CLASS id=identifier cb=classBody { cm^" class "^id^cb}
+(* To sort *)
+floatingPointType:
+    FLOAT { "float" } 
+
+identifier:
+    id=IDENT { id }
+
+integralType:
+    INT { "int" } 
+    
+methodBody:
+    SEMICOLON { ";" }
 
 numericType:
       it=integralType { it } 
@@ -89,9 +114,6 @@ numericType:
 
 result:
     ut=unannType { ut }
-
-typeDeclaration:
-    cd=classDeclaration { cd }
 
 unannPrimitiveType:
     nt=numericType { nt }

--- a/Tests/classmethoddeclaration.java
+++ b/Tests/classmethoddeclaration.java
@@ -1,0 +1,3 @@
+public class Point { 
+	int reset ();
+}


### PR DESCRIPTION
Basé sur la spec de Java 6, le code en l'état actuel permet de parser un code comme celui-ci : 

public class Point {
  int reset();
}

Par contre, la déclaration d'attribut n'est pas possible, et il faut travailler sur cela. Je pense que la déclaration d'attribut a des différences **grammaticales** avec la déclaration de variables (dans le corps d'une fonction). 

Je vais essayer d'introduire des paramètres dans les fonctions.
