### PR TITLE
Types.ml: Creation of Types for AST

### DIFF
--- a/Parsing/parser.mly
+++ b/Parsing/parser.mly
@@ -1,3 +1,7 @@
+%{ 
+    open Types
+    %}
+
 (* operators *)
 
 (* delimitors *)
@@ -37,6 +41,9 @@ normalClassDeclaration:
       CLASS id=identifier cb=classBody { "class "^id^" "^cb } 
     | cms=classModifiers CLASS id=identifier cb=classBody { cms^" class "^id^" "^cb }
 
+identifier:
+    id=IDENT { id }
+
 classModifiers:
       cm=classModifier { cm }
     | cms=classModifiers cm=classModifier { cms^" "^cm }
@@ -51,6 +58,10 @@ classModifier:
     | STRICTFP { "strictfp" }
 
 classBody:
+    | LBRACE RBRACE { CLASSBODY }
+
+(*
+ classBody:
       LBRACE cbds=classBodyDeclarations RBRACE { " {"^cbds^" }" }
     | LBRACE RBRACE { " {} "}
 
@@ -130,4 +141,5 @@ variableDeclaratorId:
 variableDeclaratorList:
     vd=variableDeclarator { vd }
     | vd=variableDeclarator COMMA vdl=variableDeclaratorList { vd^", "^vdl }
+*)
 %%

--- a/Parsing/types.ml
+++ b/Parsing/types.ml
@@ -1,0 +1,24 @@
+type classDeclaration = 
+    | ClassDeclaration of classDeclaration
+    | EnumDeclaration of enumDeclaration
+
+type normalClassDeclaration = 
+    NormalClassDeclaration of ( classmodifiers * jclass * identifier * classbody )
+
+type modifiers = 
+    | PUBLIC
+    | PROTECTED
+    | PRIVATE
+    | ABSTRACT
+    | STATIC
+    | FINAL
+    | STRICTFP
+
+type jclass = CLASS
+
+type identifier = IDENTIFIER of string
+
+(* 
+ * type classBody = ... ???
+ *
+ * ) 

--- a/Parsing/types.ml
+++ b/Parsing/types.ml
@@ -1,11 +1,11 @@
 type classDeclaration = 
     | ClassDeclaration of classDeclaration
-    | EnumDeclaration of enumDeclaration
 
 type normalClassDeclaration = 
-    NormalClassDeclaration of ( classmodifiers * jclass * identifier * classbody )
+    NormalClassDeclaration of classModifiers * jclass * identifier * classbody
 
-type modifiers = 
+type classModifiers = 
+    | EMPTY
     | PUBLIC
     | PROTECTED
     | PRIVATE
@@ -18,7 +18,4 @@ type jclass = CLASS
 
 type identifier = IDENTIFIER of string
 
-(* 
- * type classBody = ... ???
- *
- * ) 
+type classbody = CLASSBODY of string


### PR DESCRIPTION
J'ai un peu regardé ce qu'il faut faire pour l'AST, mais je comprends pas tout encore. Il faut créer des types pour chaque structure du langage Java. 

On a fait ça, en TP, avec les expressions. Il faut regarder la correction du tp 2&3 sur menhir. 

C'est encore du work in progress, c'était juste pour vous montrer. 

A +
